### PR TITLE
Hidden checkbox configuration option

### DIFF
--- a/persistent_login.install
+++ b/persistent_login.install
@@ -60,6 +60,7 @@ function persistent_login_schema() {
 function persistent_login_uninstall() {
   // Delete all module variables.
   variable_del('persistent_login_welcome');
+  variable_del('persistent_login_hidden');
   variable_del('persistent_login_maxlife');
   variable_del('persistent_login_maxlogins');
   variable_del('persistent_login_secure');

--- a/persistent_login.module
+++ b/persistent_login.module
@@ -164,12 +164,22 @@ function persistent_login_form_alter(&$form, $form_state, $form_id) {
       '#type' => 'checkbox',
       '#title' => t('Remember me'),
     );
+    if (variable_get('persistent_login_hidden', FALSE)) {
+        $form['account']['persistent_login']['#prefix'] = '<div style="display:none;">';
+        $form['account']['persistent_login']['#value'] = '1';
+        $form['account']['persistent_login']['#suffix'] = '</div>';
+    }
   }
   else {
     $form['persistent_login'] = array(
       '#type' => 'checkbox',
       '#title' => t('Remember me'),
     );
+      if (variable_get('persistent_login_hidden', FALSE)) {
+        $form['persistent_login']['#prefix'] = '<div style="display:none;">';
+        $form['persistent_login']['#value'] = '1';
+        $form['persistent_login']['#suffix'] = '</div>';
+    }
   }
 
   // Add an after_build callback that we'll use to adjust the weight

--- a/persistent_login.pages.inc
+++ b/persistent_login.pages.inc
@@ -22,6 +22,13 @@ function persistent_login_admin_settings($form, &$form_state) {
     '#description' => t('If checked, the message \'Welcome back, <em>username</em>\' will be displayed each time a new login session is created via a Persistent Login cookie.'),
   );
 
+  $form['persistent_login_hidden'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Hide the remember me checkbox'),
+    '#default_value' => variable_get('persistent_login_hidden', FALSE),
+    '#description' => t('If it is checked, then the checkbox is not displayed in the login forms and the remember me feature is always enabled.'),
+  );
+
   $form['persistent_login_maxlife'] = array(
     '#type' => 'textfield',
     '#title' => t('Days to remember the user'),


### PR DESCRIPTION
I added a plugin configuration checkbox for variable persistent_login_hidden.
When this option is checked the "rememeber me" checkbox is hidden and always set.
